### PR TITLE
Add dnscontrol install path to $PATH

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -139,6 +139,7 @@ runs:
         mkdir -p "$RESOLVED_TEMP"
         $CURL -L "${URL}" | tar -C "$RESOLVED_TEMP" -xvzf - dnscontrol
         echo "$RESOLVED_TEMP" >>"$GITHUB_PATH"
+        echo "DNSCONTROL=$RESOLVED_TEMP/dnscontrol" >>"$GITHUB_ENV"
         $RESOLVED_TEMP/dnscontrol version
 
     - name: DNSControl check

--- a/action.yml
+++ b/action.yml
@@ -151,7 +151,7 @@ runs:
       run: |
         # DNSControl check
         set +e
-        DNSCONTROL_CMD=$(dnscontrol check --config "$DNSCONFIG_FILE" 2>&1)
+        DNSCONTROL_CMD=$($DNSCONTROL check --config "$DNSCONFIG_FILE" 2>&1)
         err=$?
         export DNSCONTROL_CMD
         DELIMITER="DNSCONTROL-$RANDOM"
@@ -210,7 +210,7 @@ runs:
       run: |
         # DNSControl
         set +e
-        DNSCONTROL_CMD=$(dnscontrol $DNSCONTROL_COMMAND --config "$DNSCONFIG_FILE" $CREDS_ARG 2>&1)
+        DNSCONTROL_CMD=$($DNSCONTROL $DNSCONTROL_COMMAND --config "$DNSCONFIG_FILE" $CREDS_ARG 2>&1)
         err=$?
         DELIMITER="DNSCONTROL-$RANDOM"
         {

--- a/action.yml
+++ b/action.yml
@@ -135,11 +135,11 @@ runs:
         TEMP: ${{ runner.temp }}
       run: |
         # Download DNSControl
-        $CURL -L "${URL}" \
-          | tar -C "$TEMP" -xvzf - dnscontrol
-        DNSCONTROL=$(readlink -f "$TEMP/dnscontrol")
-        echo "DNSCONTROL=$DNSCONTROL" >>"$GITHUB_ENV"
-        $DNSCONTROL version
+        RESOLVED_TEMP="$(readlink -e $TEMP)/dnscontrol$RANDOM"
+        mkdir -p "$RESOLVED_TEMP"
+        $CURL -L "${URL}" | tar -C "$RESOLVED_TEMP" -xvzf - dnscontrol
+        echo "$RESOLVED_TEMP" >>"$GITHUB_PATH"
+        $RESOLVED_TEMP/dnscontrol version
 
     - name: DNSControl check
       if: ${{ inputs.check == 'true' }}
@@ -151,7 +151,7 @@ runs:
       run: |
         # DNSControl check
         set +e
-        DNSCONTROL_CMD=$($DNSCONTROL check --config "$DNSCONFIG_FILE" 2>&1)
+        DNSCONTROL_CMD=$(dnscontrol check --config "$DNSCONFIG_FILE" 2>&1)
         err=$?
         export DNSCONTROL_CMD
         DELIMITER="DNSCONTROL-$RANDOM"
@@ -210,7 +210,7 @@ runs:
       run: |
         # DNSControl
         set +e
-        DNSCONTROL_CMD=$($DNSCONTROL $DNSCONTROL_COMMAND --config "$DNSCONFIG_FILE" $CREDS_ARG 2>&1)
+        DNSCONTROL_CMD=$(dnscontrol $DNSCONTROL_COMMAND --config "$DNSCONFIG_FILE" $CREDS_ARG 2>&1)
         err=$?
         DELIMITER="DNSCONTROL-$RANDOM"
         {


### PR DESCRIPTION
This allows running the dnscontrol command directly in consuming workflow's steps.

Fixes #7 