### PR TITLE
bugfix(action.yaml): Save output to a tmp file, not an env variable

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -257,7 +257,7 @@ runs:
         exit $err
 
     - name: Attach Check Results as PR comment
-      uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
+      uses: https://github.com/thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
       # execute if user set post_pr_comment, this is a PR event, AND dnscontrol check ran and failed
       if: ${{
              inputs.post_pr_comment &&
@@ -327,7 +327,7 @@ runs:
         echo "output_file=$OUTPUT_FILE" >>"$GITHUB_OUTPUT"
 
     - name: Attach Results as PR comment
-      uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
+      uses: https://github.com/thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
       # execute if user set post_pr_comment, this is a PR event, AND dnscontrol job ran
       if: ${{ inputs.post_pr_comment && github.event.pull_request.number != '' && steps.dnscontrol.outcome != 'skipped' }}
       with:

--- a/action.yml
+++ b/action.yml
@@ -297,20 +297,21 @@ runs:
       if: ${{ steps.check.outcome == 'success' || steps.check.outcome == 'skipped' }}
       continue-on-error: true
       shell: bash
-      env:
-        NO_COLOR: 'true'
-        DNSCONTROL_COMMAND: ${{ inputs.cmdargs }}
       run: |
         # DNSControl
         set +e
-        DNSCONTROL_CMD=$($DNSCONTROL $DNSCONTROL_COMMAND --config "$DNSCONFIG_FILE" $CREDS_ARG 2>&1)
-        err=$?
+        TMP_OUT="$(mktemp)"
+        
+        $DNSCONTROL ${{ inputs.cmdargs }} --config "$DNSCONFIG_FILE" $CREDS_ARG 2>&1 | tee "$TMP_OUT"
+        err=${PIPESTATUS[0]}
+
         DELIMITER="DNSCONTROL-$RANDOM"
         {
           echo "output<<$DELIMITER"
-          echo "$DNSCONTROL_CMD"
+          cat "$TMP_OUT"
           echo "$DELIMITER"
         } >>"$GITHUB_OUTPUT"
+        rm -f "$TMP_OUT"
         exit $err
 
     - name: Write output file

--- a/action.yml
+++ b/action.yml
@@ -297,12 +297,13 @@ runs:
       if: ${{ steps.check.outcome == 'success' || steps.check.outcome == 'skipped' }}
       continue-on-error: true
       shell: bash
+      env:
+        DNSCONTROL_COMMAND: ${{ inputs.cmdargs }}
       run: |
         # DNSControl
         set +e
         TMP_OUT="$(mktemp)"
-        
-        $DNSCONTROL ${{ inputs.cmdargs }} --config "$DNSCONFIG_FILE" $CREDS_ARG 2>&1 | tee "$TMP_OUT"
+        $DNSCONTROL $DNSCONTROL_COMMAND --config "$DNSCONFIG_FILE" $CREDS_ARG 2>&1 | tee "$TMP_OUT"
         err=${PIPESTATUS[0]}
 
         DELIMITER="DNSCONTROL-$RANDOM"


### PR DESCRIPTION
Hi there,

as seen in my Issue we had problems on the Forgejo Platform.

This PR solves it. The problem was, that Forgejo resolved the hollander action internally to code.forgejo.com thus failing with Error 128 and failing the entire run. By using the FQDN it is downloaded correctly.

Also we do not need output as a comment but rather in the action (second Commit) which enables the colored output again but still preserves outgoing output for the following comment.