### PR TITLE
fixes wrong test of post_pr_comment input

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -260,7 +260,7 @@ runs:
       uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
       # execute if user set post_pr_comment, this is a PR event, AND dnscontrol check ran and failed
       if: ${{
-             inputs.post_pr_comment &&
+             inputs.post_pr_comment == 'true' &&
              github.event.pull_request.number != '' &&
              (
                steps.check.outcome != 'skipped' &&
@@ -329,7 +329,10 @@ runs:
     - name: Attach Results as PR comment
       uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
       # execute if user set post_pr_comment, this is a PR event, AND dnscontrol job ran
-      if: ${{ inputs.post_pr_comment && github.event.pull_request.number != '' && steps.dnscontrol.outcome != 'skipped' }}
+      if: ${{
+             inputs.post_pr_comment == 'true' &&
+             github.event.pull_request.number != '' &&
+             steps.dnscontrol.outcome != 'skipped' }}
       with:
         comment-tag: dnscontrol_composite_action
         message: |


### PR DESCRIPTION
This corrects the behavior when setting `post_pr_comment: false` where previously the action tested the input as if it was a boolean, any non-null string would evaluate to true.

fixes #64