### PR TITLE
Forgejo support

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ with:
   post_pr_comment: true
   post_summary: true
 ```
+**Note for Forgejo Users**
+
+This action has been tested on Forgejo Actions and can be used as above, with a change to call the action at this project URL
+```yaml
+uses: https://github.com/DNSControl/dnscontrol-action
+```
 
 **Simple DNSControl Preview Example**
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This is a composite GitHub action for running configurable DNSControl commands.
 * Specify alternate locations for `dnsconfig.js` and `creds.json`
 * Choose which version of DNSControl to run (the default is the latest release)
 
-# Credentials
+## Credentials
 
 Do NOT store API keys or other credentials in a git repo!
 
@@ -101,8 +101,27 @@ jobs:
           check: true
 ```
 
-### Contributing
+## Contributing
 
 PRs welcome!
 
-Changes or additions to the shell scripts in action.yml should pass `shellcheck -S warning`. A PR workflow will run a shellcheck wrapper (`bin/shellcheck.sh`) and any findings at warning or error levels will fail the check. The wrapper script has been tested in Bash 5.2 and zsh 5.9 on Linux and MacOS.
+Changes or additions to the shell scripts and action `run` steps must pass `bin/shellcheck.sh`. Any findings at warning or error levels will fail the check. The wrapper script has been tested in Bash 5.2 and zsh 5.9 on Linux and MacOS.
+
+### Testing
+
+To assist with troubleshooting changes, debug output can be enabled:
+
+```yaml
+uses: DNSControl/dnscontrol-action
+env:
+  DEBUG_ACTION: true
+with:
+  cmdargs: ...
+```
+
+New debug statements can be added to the action by using `$DEBUG` in place of `echo`
+```shell
+... other code ...
+$DEBUG "new output here"
+...
+```

--- a/action.yml
+++ b/action.yml
@@ -266,12 +266,8 @@ runs:
         # Download DNSControl
         $FJECHO "Download DNSControl"
         $CURL -H "Accept: application/octet-stream" \
-          -L "${URL}" -o "$TEMP/dnscontrol.$EXT"
-
-        $CURL -H "Accept: application/octet-stream" \
           -H "X-GitHub-Api-Version: 2022-11-28" \
-          -L "${URL}" \
-          -o "$TEMP/dnscontrol.$EXT"
+          -L "${URL}" -o "$TEMP/dnscontrol.$EXT"
         echo "file=$TEMP/dnscontrol.$EXT" >>"$GITHUB_OUTPUT"
 
     - name: Unpack DNSControl - Linux or macOS

--- a/action.yml
+++ b/action.yml
@@ -69,6 +69,22 @@ runs:
         echo "::error title=error::Action supports Linux, Windows, and macOS only"
         exit 1
 
+    - name: Debug Helpers
+      shell: bash
+      env:
+        DEBUG: ${{ env.DEBUG_ACTION }}
+      run: |
+        if [[ -n "$FORGEJO_REPOSITORY" ]]; then
+          echo "FJECHO=echo" >>"$GITHUB_ENV"
+        else
+          echo "FJECHO=/bin/true" >>"$GITHUB_ENV"
+        fi
+        if [[ "${DEBUG}" == "true" ]]; then
+          echo "DEBUG=echo" >>"$GITHUB_ENV"
+        else
+          echo "DEBUG=/bin/true" >>"$GITHUB_ENV"
+        fi
+
     - name: Sanitize inputs
       env:
         DNSCONTROL_VERSION: ${{ inputs.version }}
@@ -79,6 +95,7 @@ runs:
       shell: bash
       run: |
         # Sanitize inputs
+        $FJECHO "Sanitize inputs"
         set +e
         echo "OUTPUT_FILE=$OUTPUT_FILE" >>"$GITHUB_ENV"
 
@@ -103,8 +120,9 @@ runs:
         echo "DNSCONTROL_VERSION=$DNSCONTROL_VERSION" >>"$GITHUB_ENV"
 
         # set default curl args
-        CURL='curl -H user-agent:official-dnscontrol-action -fsS --retry 5 --retry-max-time 30'
-        CURLJSON="$CURL -H Accept:application/vnd.github.v3+json "
+        CURL="curl -fsS --retry 5 --retry-max-time 30 -H user-agent:official-dnscontrol-action -H X-GitHub-Api-Version:2022-11-28"
+        CURLJSON="$CURL -H Accept:application/vnd.github.v3+json,application/json"
+        
         echo "CURL=$CURL" >>"$GITHUB_ENV"
         echo "CURLJSON=$CURLJSON" >>"$GITHUB_ENV"
 
@@ -120,6 +138,43 @@ runs:
         esac
         echo "CREDS_ARG=$CREDS_ARG" >>"$GITHUB_ENV"
 
+    - name: Resolve Comment Helpers
+      shell: bash
+      if: ${{ inputs.post_pr_comment == 'true' }}
+      id: comment_api
+      env:
+        REPO: ${{ github.repository }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+      run: |
+        # Resolve Comment Helpers
+        $FJECHO "Resolve Comment Helpers"
+
+        echo "marker=<!-- dnscontrol_composite_action -->" >>"$GITHUB_OUTPUT"
+
+        GIT_HOST=$(git config --get remote.origin.url | sed -E 's|.*@([^/:]+).*|\1|; s|.*://([^/]+).*|\1|')
+
+        if [[ $GIT_HOST == "github.com" ]]; then
+          API_URL="https://api.github.com"
+          API_PAGER="per_page"
+          PAGE_LIMIT=5
+          echo "supported=true" >>"$GITHUB_OUTPUT"
+        elif [[ -n "$FORGEJO_REPOSITORY" ]]; then
+          API_URL="https://${GIT_HOST}/api/v1"
+          # note comment pagination not supported on Forgejo
+          echo "supported=true" >>"$GITHUB_OUTPUT"
+        else
+          echo "NOTICE: API is unknown for git host \"$GIT_HOST\" - PR comments disabled"
+          echo "supported=false" >>"$GITHUB_OUTPUT"
+        fi
+
+        PR_API_URL="${API_URL}/repos/$REPO/issues/$PR_NUMBER/comments"
+        COMMENT_API_URL="${API_URL}/repos/$REPO/issues/comments"
+
+        echo "PR_API_URL=$PR_API_URL" >>"$GITHUB_ENV"
+        echo "COMMENT_API_URL=$COMMENT_API_URL" >>"$GITHUB_ENV"
+        echo "API_PAGER=$API_PAGER" >>"$GITHUB_ENV"
+        echo "PAGE_LIMIT=$PAGE_LIMIT" >>"$GITHUB_ENV"
+
     - name: Resolve OS and Arch
       env:
         RUNNER_OS: ${{ runner.os }}
@@ -127,6 +182,7 @@ runs:
       shell: bash
       run: |
         # Resolve OS and Arch
+        $FJECHO "Resolve OS and Arch"
         case "$RUNNER_OS" in
           Linux)
             OS='linux'
@@ -173,13 +229,15 @@ runs:
       shell: bash
       run: |
         # Resolve download URL for latest
-        LATEST=$($CURLJSON -L https://api.github.com/repos/StackExchange/dnscontrol/releases/latest)
+        $FJECHO "Resolve download URL for latest"
+        LATEST=$($CURLJSON -L https://api.github.com/repos/DNSControl/dnscontrol/releases/latest)
         VERSION=$(printf '%s' $LATEST | jq -r ".tag_name")
+        echo "resolved latest version: $VERSION"
 
         PACKAGE=dnscontrol_${VERSION#v}_${OS}_${ARCH}.${EXT}
         URL=$(\
           printf '%s' $LATEST \
-          | jq -r --arg package $PACKAGE '.assets[] | select(.name == "\($package)") | .browser_download_url'\
+          | jq -r --arg package $PACKAGE '.assets[] | select(.name == "\($package)") | .url'\
         )
         echo "resolved package url: $URL"
         echo "URL=$URL" >>"$GITHUB_ENV"
@@ -189,9 +247,10 @@ runs:
       shell: bash
       run: |
         # Resolve download URL
+        $FJECHO "Resolve download URL"
         PACKAGE=dnscontrol_${DNSCONTROL_VERSION#v}_${OS}_${ARCH}.${EXT}
         URL=$(\
-          $CURLJSON -L https://api.github.com/repos/StackExchange/dnscontrol/releases \
+          $CURLJSON -L https://api.github.com/repos/DNSControl/dnscontrol/releases \
           | jq -r --arg version $DNSCONTROL_VERSION --arg package $PACKAGE \
             '.[] | select(.tag_name == "\($version)") | .assets[] | select(.name == "\($package)") | .browser_download_url' \
         )
@@ -205,7 +264,14 @@ runs:
         TEMP: ${{ runner.temp }}
       run: |
         # Download DNSControl
-        $CURL -L "${URL}" -o "$TEMP/dnscontrol.$EXT"
+        $FJECHO "Download DNSControl"
+        $CURL -H "Accept: application/octet-stream" \
+          -L "${URL}" -o "$TEMP/dnscontrol.$EXT"
+
+        $CURL -H "Accept: application/octet-stream" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          -L "${URL}" \
+          -o "$TEMP/dnscontrol.$EXT"
         echo "file=$TEMP/dnscontrol.$EXT" >>"$GITHUB_OUTPUT"
 
     - name: Unpack DNSControl - Linux or macOS
@@ -216,6 +282,7 @@ runs:
         PACKAGE: ${{ steps.download.outputs.file }}
       run: |
         # Unpack DNSControl - Linux or macOS
+        $FJECHO "Unpack DNSControl - Linux or macOS"
         RESOLVED_TEMP="$(readlink -f $TEMP)/dnscontrol$RANDOM"
         mkdir -p "$RESOLVED_TEMP"
         tar -C "$RESOLVED_TEMP" -xvzf $PACKAGE dnscontrol
@@ -231,6 +298,7 @@ runs:
         PACKAGE: ${{ steps.download.outputs.file }}
       run: |
         # Unpack DNSControl - Windows
+        $FJECHO "Unpack DNSControl - Windows"
         RESOLVED_TEMP="$TEMP/dnscontrol$RANDOM" # windows lacks readlink, so this may be relative
         mkdir -p "$RESOLVED_TEMP"
         unzip -d "$RESOLVED_TEMP" $PACKAGE dnscontrol.exe
@@ -247,33 +315,35 @@ runs:
         NO_COLOR: 'true'
       run: |
         # DNSControl check
+        $FJECHO "DNSControl check"
         set +e
-        DNSCONTROL_CMD=$($DNSCONTROL check --config "$DNSCONFIG_FILE" 2>&1)
-        err=$?
-        export DNSCONTROL_CMD
+        TMP_OUT="$(mktemp)"
+        $DNSCONTROL check --config "$DNSCONFIG_FILE" 2>&1 | tee "$TMP_OUT"
+        err=${PIPESTATUS[0]}
+
         DELIMITER="DNSCONTROL-$RANDOM"
         {
           echo "output<<$DELIMITER"
-          echo "$DNSCONTROL_CMD"
+          cat "$TMP_OUT"
           echo "$DELIMITER"
         } >>"$GITHUB_OUTPUT"
-        echo "$DNSCONTROL_CMD"
+        rm -f "$TMP_OUT"
         exit $err
 
     - name: Attach Check Results as PR comment
-      uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
-      # execute if user set post_pr_comment, this is a PR event, AND dnscontrol check ran and failed
+      # execute if comment api is supported, user set post_pr_comment=true, this is a PR event, AND dnscontrol check ran and failed
       if: ${{
+             steps.comment_api.outputs.supported == 'true' &&
              inputs.post_pr_comment == 'true' &&
              github.event.pull_request.number != '' &&
              (
                steps.check.outcome != 'skipped' &&
                steps.check.outcome != 'success'
              ) }}
-      with:
-        # comment-tag must be the same for both PR comment steps so they update the same comment
-        comment-tag: dnscontrol_composite_action
-        message: |
+      shell: bash
+      env:
+        API_TOKEN: ${{ github.token }}
+        COMMENT_BODY: |
           <details open><summary>DNSControl Check Results</summary>
 
           ### DNSControl Check Results
@@ -282,6 +352,48 @@ runs:
           ${{ steps.check.outputs.output }}
           ```
           </details>
+          ${{ steps.comment_api.outputs.marker }}
+      run: |
+        # Attach Check Results as PR comment
+        $FJECHO "Attach Check Results as PR comment"
+        comment_id=""
+        page=1
+        while [[ -z "$comment_id" ]]; do
+          if [[ -n "$API_PAGER" ]]; then
+            query_string="?${API_PAGER}=$PAGE_LIMIT&page=$page"
+          else
+            query_string=""
+          fi
+          $DEBUG "fetching page $page of PR comments:"
+          $DEBUG "${PR_API_URL}${query_string}"
+
+          comments=$($CURLJSON -H "Authorization: Token ${API_TOKEN}" \
+            "${PR_API_URL}${query_string}")
+          comment_id=$(printf '%s' "$comments" \
+            | jq -r '[.[] | select(.body | contains("${{ steps.comment_api.outputs.marker }}")) | .id] | first // empty')
+
+          comments_length=$(printf '%s' "$comments" | jq 'length')
+          $DEBUG "API returned $comments_length comments"
+
+          # codeberg ignores the page limit
+          if [[ -z "$API_PAGER" ]] || \
+             [[ $comments_length -lt $PAGE_LIMIT ]] || \
+             [[ -n "$comment_id" ]]; then
+            break
+          fi
+          ((page++))
+        done
+
+        comment_payload=$(jq -n --arg body "$COMMENT_BODY" '{body: $body}')
+
+        if [[ -n "$comment_id" ]]; then
+          comment=$($CURLJSON -X PATCH -H "Authorization: Token ${API_TOKEN}" --json "$comment_payload" \
+            "${COMMENT_API_URL}/$comment_id")
+        else
+          comment=$($CURLJSON -X POST -H "Authorization: Token ${API_TOKEN}" --json "$comment_payload" \
+            "${PR_API_URL}")
+        fi
+        $DEBUG $comment
 
     - name: Check Summary
       # write check output to job summary if check failed
@@ -291,6 +403,7 @@ runs:
         OUTPUT: ${{ steps.check.outputs.output }}
       run: |
         # Check Summary
+        $FJECHO "Check Summary"
         echo "$OUTPUT" >>$"GITHUB_STEP_SUMMARY"
         # check failed, stop the job
         exit 1
@@ -305,6 +418,7 @@ runs:
         DNSCONTROL_COMMAND: ${{ inputs.cmdargs }}
       run: |
         # DNSControl
+        $FJECHO "DNSControl"
         set +e
         TMP_OUT="$(mktemp)"
         $DNSCONTROL $DNSCONTROL_COMMAND --config "$DNSCONFIG_FILE" $CREDS_ARG 2>&1 | tee "$TMP_OUT"
@@ -329,19 +443,21 @@ runs:
         OUTPUT: ${{ steps.dnscontrol.outputs.output }}
       run: |
         # Write output file
+        $FJECHO "Write output file"
         echo "$OUTPUT" > "$OUTPUT_FILE"
         echo "output_file=$OUTPUT_FILE" >>"$GITHUB_OUTPUT"
 
     - name: Attach Results as PR comment
-      uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
-      # execute if user set post_pr_comment, this is a PR event, AND dnscontrol job ran
+      # execute if comment api is supported, user set post_pr_comment=true, this is a PR event, AND dnscontrol command ran
       if: ${{
+             steps.comment_api.outputs.supported == 'true' &&
              inputs.post_pr_comment == 'true' &&
              github.event.pull_request.number != '' &&
              steps.dnscontrol.outcome != 'skipped' }}
-      with:
-        comment-tag: dnscontrol_composite_action
-        message: |
+      shell: bash
+      env:
+        API_TOKEN: ${{ github.token }}
+        COMMENT_BODY: |
           <details open><summary>DNSControl Results</summary>
 
           ### DNSControl Results
@@ -350,6 +466,47 @@ runs:
           ${{ steps.dnscontrol.outputs.output }}
           ```
           </details>
+          ${{ steps.comment_api.outputs.marker }}
+      run: |
+        # Attach Results as PR comment
+        $FJECHO "Attach Results as PR comment"
+        comment_id=""
+        page=1
+        while [[ -z "$comment_id" ]]; do
+          if [[ -n "$API_PAGER" ]]; then
+            query_string="?${API_PAGER}=$PAGE_LIMIT&page=$page"
+          else
+            query_string=""
+          fi
+          $DEBUG "fetching page $page of PR comments:"
+          $DEBUG "${PR_API_URL}${query_string}"
+
+          comments=$($CURLJSON -H "Authorization: Token ${API_TOKEN}" \
+            "${PR_API_URL}${query_string}")
+          comment_id=$(printf '%s' "$comments" \
+            | jq -r '[.[] | select(.body | contains("${{ steps.comment_api.outputs.marker }}")) | .id] | first // empty')
+
+          comments_length=$(printf '%s' "$comments" | jq 'length')
+          $DEBUG "API returned $comments_length comments"
+
+          if [[ -z "$API_PAGER" ]] || \
+             [[ $comments_length -lt $PAGE_LIMIT ]] || \
+             [[ -n "$comment_id" ]]; then
+            break
+          fi
+          ((page++))
+        done
+
+        comment_payload=$(jq -n --arg body "$COMMENT_BODY" '{body: $body}')
+
+        if [[ -n "$comment_id" ]]; then
+          comment=$($CURLJSON -X PATCH -H "Authorization: Token ${API_TOKEN}" --json "$comment_payload" \
+            "${COMMENT_API_URL}/$comment_id")
+        else
+          comment=$($CURLJSON -X POST -H "Authorization: Token ${API_TOKEN}" --json "$comment_payload" \
+            "${PR_API_URL}")
+        fi
+        $DEBUG $comment
 
     - name: Job Summary
       id: job_summary
@@ -360,6 +517,7 @@ runs:
         OUTPUT: ${{ steps.dnscontrol.outputs.output }}
       run: |
         # Job Summary
+        $FJECHO "Job Summary"
         echo "$OUTPUT" >>"$GITHUB_STEP_SUMMARY"
 
     - name: Action failed
@@ -367,5 +525,6 @@ runs:
       shell: bash
       run: |
         # Action failed
+        $FJECHO "Action failed"
         echo "::error title=error::DNSControl command failed"
         exit 1

--- a/action.yml
+++ b/action.yml
@@ -72,17 +72,22 @@ runs:
     - name: Debug Helpers
       shell: bash
       env:
-        DEBUG: ${{ env.DEBUG_ACTION }}
+        DEBUG_ACTION: ${{ env.DEBUG_ACTION }}
       run: |
+        # Debug Helpers
+        if [[ "${DEBUG_ACTION}" == "true" ]]; then
+          echo "DEBUG=echo" >>"$GITHUB_ENV"
+        else
+          # we're setting DEBUG var to the shell builtin `true` if DEBUG_ACTION
+          # var was not 'true' to make the debug statements no-ops. it's confusing, sorry.
+          echo "DEBUG=true" >>"$GITHUB_ENV"
+        fi
         if [[ -n "$FORGEJO_REPOSITORY" ]]; then
           echo "FJECHO=echo" >>"$GITHUB_ENV"
         else
+          # do not echo if we're not on a Forgejo Actions runner
+          # same as above, use shell builtin `true` to no-op the $FJECHO statements with exit 0 return
           echo "FJECHO=true" >>"$GITHUB_ENV"
-        fi
-        if [[ "${DEBUG}" == "true" ]]; then
-          echo "DEBUG=echo" >>"$GITHUB_ENV"
-        else
-          echo "DEBUG=true" >>"$GITHUB_ENV"
         fi
 
     - name: Sanitize inputs
@@ -149,7 +154,7 @@ runs:
         # Resolve Comment Helpers
         $FJECHO "Resolve Comment Helpers"
 
-        echo "marker=<!-- dnscontrol_composite_action -->" >>"$GITHUB_OUTPUT"
+        echo "marker=<!-- dnscontrol-action -->" >>"$GITHUB_OUTPUT"
 
         GIT_HOST=$(git config --get remote.origin.url | sed -E 's|.*@([^/:]+).*|\1|; s|.*://([^/]+).*|\1|')
 
@@ -339,6 +344,8 @@ runs:
       shell: bash
       env:
         API_TOKEN: ${{ github.token }}
+        MARKER: ${{ steps.comment_api.outputs.marker }}
+        STEP_TITLE: "Attach Check Results as PR comment"
         COMMENT_BODY: |
           <details open><summary>DNSControl Check Results</summary>
 
@@ -349,46 +356,7 @@ runs:
           ```
           </details>
           ${{ steps.comment_api.outputs.marker }}
-      run: |
-        # Attach Check Results as PR comment
-        $FJECHO "Attach Check Results as PR comment"
-        comment_id=""
-        page=1
-        while [[ -z "$comment_id" ]]; do
-          if [[ -n "$API_PAGER" ]]; then
-            query_string="?${API_PAGER}=$PAGE_LIMIT&page=$page"
-          else
-            query_string=""
-          fi
-          $DEBUG "fetching page $page of PR comments:"
-          $DEBUG "${PR_API_URL}${query_string}"
-
-          comments=$($CURLJSON -H "Authorization: Token ${API_TOKEN}" \
-            "${PR_API_URL}${query_string}")
-          comment_id=$(printf '%s' "$comments" \
-            | jq -r '[.[] | select(.body | contains("${{ steps.comment_api.outputs.marker }}")) | .id] | first // empty')
-
-          comments_length=$(printf '%s' "$comments" | jq 'length')
-          $DEBUG "API returned $comments_length comments"
-
-          if [[ -z "$API_PAGER" ]] || \
-             [[ $comments_length -lt $PAGE_LIMIT ]] || \
-             [[ -n "$comment_id" ]]; then
-            break
-          fi
-          ((page++))
-        done
-
-        comment_payload=$(jq -n --arg body "$COMMENT_BODY" '{body: $body}')
-
-        if [[ -n "$comment_id" ]]; then
-          comment=$($CURLJSON -X PATCH -H "Authorization: Token ${API_TOKEN}" --json "$comment_payload" \
-            "${COMMENT_API_URL}/$comment_id")
-        else
-          comment=$($CURLJSON -X POST -H "Authorization: Token ${API_TOKEN}" --json "$comment_payload" \
-            "${PR_API_URL}")
-        fi
-        $DEBUG $comment
+      run: bin/comment.sh
 
     - name: Check Summary
       # write check output to job summary if check failed
@@ -452,6 +420,8 @@ runs:
       shell: bash
       env:
         API_TOKEN: ${{ github.token }}
+        MARKER: ${{ steps.comment_api.outputs.marker }}
+        STEP_TITLE: "Attach Results as PR comment"
         COMMENT_BODY: |
           <details open><summary>DNSControl Results</summary>
 
@@ -462,46 +432,7 @@ runs:
           ```
           </details>
           ${{ steps.comment_api.outputs.marker }}
-      run: |
-        # Attach Results as PR comment
-        $FJECHO "Attach Results as PR comment"
-        comment_id=""
-        page=1
-        while [[ -z "$comment_id" ]]; do
-          if [[ -n "$API_PAGER" ]]; then
-            query_string="?${API_PAGER}=$PAGE_LIMIT&page=$page"
-          else
-            query_string=""
-          fi
-          $DEBUG "fetching page $page of PR comments:"
-          $DEBUG "${PR_API_URL}${query_string}"
-
-          comments=$($CURLJSON -H "Authorization: Token ${API_TOKEN}" \
-            "${PR_API_URL}${query_string}")
-          comment_id=$(printf '%s' "$comments" \
-            | jq -r '[.[] | select(.body | contains("${{ steps.comment_api.outputs.marker }}")) | .id] | first // empty')
-
-          comments_length=$(printf '%s' "$comments" | jq 'length')
-          $DEBUG "API returned $comments_length comments"
-
-          if [[ -z "$API_PAGER" ]] || \
-             [[ $comments_length -lt $PAGE_LIMIT ]] || \
-             [[ -n "$comment_id" ]]; then
-            break
-          fi
-          ((page++))
-        done
-
-        comment_payload=$(jq -n --arg body "$COMMENT_BODY" '{body: $body}')
-
-        if [[ -n "$comment_id" ]]; then
-          comment=$($CURLJSON -X PATCH -H "Authorization: Token ${API_TOKEN}" --json "$comment_payload" \
-            "${COMMENT_API_URL}/$comment_id")
-        else
-          comment=$($CURLJSON -X POST -H "Authorization: Token ${API_TOKEN}" --json "$comment_payload" \
-            "${PR_API_URL}")
-        fi
-        $DEBUG $comment
+      run: bin/comment.sh
 
     - name: Job Summary
       id: job_summary

--- a/action.yml
+++ b/action.yml
@@ -237,7 +237,7 @@ runs:
         PACKAGE=dnscontrol_${VERSION#v}_${OS}_${ARCH}.${EXT}
         URL=$(\
           printf '%s' $LATEST \
-          | jq -r --arg package $PACKAGE '.assets[] | select(.name == "\($package)") | .url'\
+          | jq -r --arg package $PACKAGE '.assets[] | select(.name == "\($package)") | .browser_download_url'\
         )
         echo "resolved package url: $URL"
         echo "URL=$URL" >>"$GITHUB_ENV"

--- a/action.yml
+++ b/action.yml
@@ -77,12 +77,12 @@ runs:
         if [[ -n "$FORGEJO_REPOSITORY" ]]; then
           echo "FJECHO=echo" >>"$GITHUB_ENV"
         else
-          echo "FJECHO=/bin/true" >>"$GITHUB_ENV"
+          echo "FJECHO=true" >>"$GITHUB_ENV"
         fi
         if [[ "${DEBUG}" == "true" ]]; then
           echo "DEBUG=echo" >>"$GITHUB_ENV"
         else
-          echo "DEBUG=/bin/true" >>"$GITHUB_ENV"
+          echo "DEBUG=true" >>"$GITHUB_ENV"
         fi
 
     - name: Sanitize inputs
@@ -156,7 +156,7 @@ runs:
         if [[ $GIT_HOST == "github.com" ]]; then
           API_URL="https://api.github.com"
           API_PAGER="per_page"
-          PAGE_LIMIT=5
+          PAGE_LIMIT=50
           echo "supported=true" >>"$GITHUB_OUTPUT"
         elif [[ -n "$FORGEJO_REPOSITORY" ]]; then
           API_URL="https://${GIT_HOST}/api/v1"
@@ -371,7 +371,6 @@ runs:
           comments_length=$(printf '%s' "$comments" | jq 'length')
           $DEBUG "API returned $comments_length comments"
 
-          # codeberg ignores the page limit
           if [[ -z "$API_PAGER" ]] || \
              [[ $comments_length -lt $PAGE_LIMIT ]] || \
              [[ -n "$comment_id" ]]; then

--- a/action.yml
+++ b/action.yml
@@ -367,7 +367,7 @@ runs:
       run: |
         # Check Summary
         $FJECHO "Check Summary"
-        echo "$OUTPUT" >>$"GITHUB_STEP_SUMMARY"
+        echo "$OUTPUT" >>"$GITHUB_STEP_SUMMARY"
         # check failed, stop the job
         exit 1
 

--- a/bin/comment.sh
+++ b/bin/comment.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+# this script is called by the dnscontrol-action commenting steps. it is not
+# expected to work outside of GHA
+
+$FJECHO "$STEP_TITLE"
+comment_id=""
+page=1
+while [[ -z "$comment_id" ]]; do
+  if [[ -n "$API_PAGER" ]]; then
+    query_string="?${API_PAGER}=$PAGE_LIMIT&page=$page"
+  else
+    query_string=""
+  fi
+  $DEBUG "fetching page $page of PR comments:"
+  $DEBUG "${PR_API_URL}${query_string}"
+
+  comments=$($CURLJSON -H "Authorization: Token ${API_TOKEN}" \
+    "${PR_API_URL}${query_string}")
+  comment_id=$(printf '%s' "$comments" \
+    | jq -r '[.[] | select(.body | contains("${MARKER}")) | .id] | first // empty')
+
+  comments_length=$(printf '%s' "$comments" | jq 'length')
+  $DEBUG "API returned $comments_length comments"
+
+  if [[ -z "$API_PAGER" ]] || \
+     [[ $comments_length -lt $PAGE_LIMIT ]] || \
+     [[ -n "$comment_id" ]]; then
+    break
+  fi
+  ((page++))
+done
+
+comment_payload=$(jq -n --arg body "$COMMENT_BODY" '{body: $body}')
+
+if [[ -n "$comment_id" ]]; then
+  $DEBUG "updating comment $comment_id"
+  comment=$($CURLJSON -X PATCH -H "Authorization: Token ${API_TOKEN}" --json "$comment_payload" \
+    "${COMMENT_API_URL}/$comment_id")
+else
+  $DEBUG "posting new comment"
+  comment=$($CURLJSON -X POST -H "Authorization: Token ${API_TOKEN}" --json "$comment_payload" \
+    "${PR_API_URL}")
+fi
+$DEBUG "$comment"

--- a/bin/shellcheck.sh
+++ b/bin/shellcheck.sh
@@ -2,9 +2,11 @@
 
 set -eo pipefail
 
-# shellcheck wrapper - to be run locally and in PR workflow:
-# extract each bash run step from action.yml and all workflows and run them
-# through shellcheck for safety. requires yq and shellcheck in $PATH
+# This script checks all project shell scripts for common errors and style
+# issues. It extracts each bash run step from action.yml and all workflows and
+# runs them through shellcheck for safety. requires yq and shellcheck in $PATH
+
+# Run locally with: [bash|zsh] bin/shellcheck.sh
 
 FAILS=0
 IFS="
@@ -12,50 +14,61 @@ IFS="
 
 # Create an array of YAML files (recent bash and zsh supported here)
 if [[ -n "$BASH_VERSION" ]]; then
-  YAMLFILES=()
-  while read -r YAMLFILE; do
-      YAMLFILES+=("$YAMLFILE")
-  done < <(find action.yml .github/workflows -type f -name \*yml -print -o -name \*yaml -print)
+  scripts=()
+  while read -r script; do
+      scripts+=("$script")
+  done < <(find action.yml .github/workflows bin -type f -name \*sh -print -o -name \*yml -print -o -name \*yaml -print)
 else
   if [[ -n "$ZSH_VERSION" ]]; then
-    YAMLFILES=("${(@f)$(find action.yml .github/workflows -type f -name \*yml -print -o -name \*yaml -print)}")
+    # shellcheck disable=SC2296
+    scripts=("${(@f)$(find action.yml .github/workflows bin -type f -name \*sh -print -o -name \*yml -print -o -name \*yaml -print)}")
   else
     echo "This script requires a recent bash or zsh shell"
     exit 1
   fi
 fi
 
+errors=""
 
-for YAMLFILE in "${YAMLFILES[@]}"; do
+for script in "${scripts[@]}"; do
 
-  echo "Checking $YAMLFILE"
+  echo "Checking $script"
 
-  # find bash run steps in workflow jobs.*.steps[] and action runs.steps[] 
-  for n in $(yq '.. | select(has("steps")) | .steps[] | select(.shell == "bash") | .name' < "$YAMLFILE")
-  do
-    # do not error out while in this inner loop: we want to find all problems
+  if [[ "${script##*.}" == "sh" ]]; then
     set +e
-
-    # prepare a safe location to create a temporary script for evaluation
-    tmpscript=$(mktemp)
-
-    # extract the *.steps[].run elements into the temp file 
-    yq ".. | select(has(\"steps\")) | .steps[] | select(.name == \"$n\") | .run" < "$YAMLFILE" > "$tmpscript"
-
-    # run the checks
-    shellcheck --shell bash -S warning "$tmpscript"
-    if [ $? -ne 0 ]; then
-      echo ""
-      echo "The script in $YAMLFILE step \"$n\" did not pass shellcheck"
-      echo ""
+    if ! shellcheck --shell bash -S warning "$script"; then
+      errors="$errors\n$script did not pass shellcheck"
       ((FAILS++))
     fi
-    rm "$tmpscript"
     set -e
-  done
+  fi
+
+  if [[ "${script##*.}" == "yml" ]] || [[ "${script#*.}" == "yaml" ]]; then
+    # find bash run steps in workflow jobs.*.steps[] and action runs.steps[]
+    for n in $(yq '.. | select(has("steps")) | .steps[] | select(.shell == "bash") | .name' < "$script")
+    do
+      # do not error out while in this inner loop: we want to find all problems
+      set +e
+
+      # prepare a safe location to create a temporary script for evaluation
+      tmpscript=$(mktemp)
+
+      # extract the *.steps[].run elements into the temp file
+      yq ".. | select(has(\"steps\")) | .steps[] | select(.name == \"$n\") | .run" < "$script" > "$tmpscript"
+
+      # run the checks
+      if ! shellcheck --shell bash -S warning "$tmpscript"; then
+        errors="$errors\n$script step \"$n\" did not pass shellcheck"
+        ((FAILS++))
+      fi
+      rm "$tmpscript"
+      set -e
+    done
+  fi
 done
 
 if [[ $FAILS -ne 0 ]]; then
   echo "$FAILS error(s) or warning(s) detected, please fix and run bin/shellcheck.sh again"
+  echo "issues:$errors"
   exit 1
 fi


### PR DESCRIPTION
This adds support for running dnscontrol-action in Forgejo Actions. Tested on Codeberg but any Forgejo instance should be compatible. No changes are needed on the user side apart from the `uses` argument in the step definition needs to reference the full URL to the project (this applies only to Forgejo Actions users).

Usage in Forgejo Actions:

```yaml
- name: DNSControl preview
  uses: https://github.com/DNSControl/dnscontrol-action
  with:
    cmdargs: preview
```

Changes:

* Forgejo Actions support
* Downloading releases is more reliable in GHA and Forgejo Actions
* The action is now self contained, no external actions called
* Run shellcheck on files matching `bin/*sh`
* Better debugging capability to assist with testing. To get debug output, run with `DEBUG_ACTION: true` set in an `env` block.